### PR TITLE
HTTPS Server Fully Implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ TODO:
 - [x] Implement data response and check in status intervals
 - [x] Implement registering custom functions
 - [x] Consider creating a "color" library in core to handle custom colors across the entire application
-- [ ] Port finished HTTP server to HTTPs
-- [ ] Enhance custom functions
+- [x] Port finished HTTP server to HTTPs
+- [x] Enhance custom functions
 - [ ] Implement TCP listener
 - [ ] Consider Implementing UDP listener
+- [ ] Implement extended functions like upload/download and any other seemingly "universal" switches
 - [ ] Consider random PSK generation rather than a default base key (keeping default for now for testing)
 - [ ] Document "API" and consider pre-generating API documentation.
+- [ ] Document core features: TLS generation, custom functions (part of API but notable), implant baseline implementation
 - [ ] Reformat the ASCII art so it is printed a bit more cleanly
 - [ ] Create demo implants to show off all the feature/functionality
 - [ ] Repo art update and open source!

--- a/core/implants.go
+++ b/core/implants.go
@@ -11,14 +11,14 @@ type Implant struct {
 	Commands  []string
 	Update    float64
 	response  string
-	Functions []string
+	Functions map[string]interface{}
 }
 
 // ZeroedUUID - zeroed global used to clear UUIDs wherever applicable
 var ZeroedUUID, _ = uuid.Parse("00000000-0000-0000-0000-000000000000")
 
 // RegisterImplant - function to register a new implant and increment the ImplantID
-func RegisterImplant(arch string, updateInterval float64, functions []string) Implant {
+func RegisterImplant(arch string, updateInterval float64, functions map[string]interface{}) Implant {
 
 	implantID := uuid.New()
 
@@ -34,7 +34,7 @@ func RegisterImplant(arch string, updateInterval float64, functions []string) Im
 }
 
 // UpdateImplant - function to update common implant fields on a given check in cycle
-func UpdateImplant(sessionID int, updateInterval float64, functions []string) {
+func UpdateImplant(sessionID int, updateInterval float64, functions map[string]interface{}) {
 	var sessionUpdate = Sessions[sessionID]
 
 	if updateInterval != 0 {

--- a/core/sessions.go
+++ b/core/sessions.go
@@ -173,13 +173,14 @@ func InitializeSessionCLI(sessionApp *grumble.App, activeSession int) {
 		Help:     "loads custom functions for a given implant",
 		LongHelp: "Loads custom functions registered by an implant tied to the current session if any exist",
 		Run: func(c *grumble.Context) error {
-			for i := range Sessions[activeSession].Implant.Functions {
+			for key, value := range Sessions[activeSession].Implant.Functions {
 
-				command := Sessions[activeSession].Implant.Functions[i]
+				command := key
+				info := value.(string)
+
 				implantFunction := &grumble.Command{
-					Name:     command,
-					Help:     "custom implant command",
-					LongHelp: "Custom implant command",
+					Name: command,
+					Help: info,
 					Run: func(c *grumble.Context) error {
 
 						QueueImplantCommand(activeSession, command)

--- a/generate_tls_cert.sh
+++ b/generate_tls_cert.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+echo "This script is just a helper to quickly generate self-signed TLS certs for Lupo C2"
+echo "This script depends on openssl to be installed, so if it is not please install it now..."
+read -n 1 -s -r -p "press enter to continue..."
+DAYS=$1
+echo "Generating private key..."
+echo ""
+openssl genrsa -out lupo-server.key 2048
+openssl ecparam -genkey -name secp384r1 -out lupo-server.key
+echo ""
+echo ""
+if [ ! -z "$DAYS" ];
+then
+echo "Generating a cert with the following parameters:"
+echo ""
+echo "openssl req -new -x509 -sha256 -key lupo-server.key -out lupo-server.crt -days $DAYS"
+echo ""
+openssl req -new -x509 -sha256 -key lupo-server.key -out lupo-server.crt -days $DAYS -subj "/C=US/ST=Lupo/L=Lupo/O=Lupo/OU=Lupo/CN=localhost"
+else
+echo "Generating a cert with the following parameters:"
+echo ""
+echo "openssl req -new -x509 -sha256 -key lupo-server.key -out lupo-server.crt -days 3650"
+echo ""
+echo "To change the number of days pass in a parameter to the script and re-run it"
+echo "example: generate_tls_cert.sh <days>"
+echo ""
+openssl req -new -x509 -sha256 -key lupo-server.key -out lupo-server.crt -days 3650 -subj "/C=US/ST=Lupo/L=Lupo/O=Lupo/OU=Lupo/CN=localhost"
+fi
+echo ""
+echo "Generating PEM file to use with Lupo implants/clients..."
+cat lupo-server.key > lupo-server.pem
+cat lupo-server.crt >> lupo-server.pem
+echo ""
+echo "Place the key and crt files in the same directory as the lupo server binary."
+echo "Alternatively, specify them with the appropriate arguments when starting an HTTPS listener."
+echo "By default Lupo will look for a key and cert named lupo-server.key and lupo-server.crt in its current directory."
+echo "You may also specify the key and cert locations via custom arguments in the listener."

--- a/server/http.go
+++ b/server/http.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/google/uuid"
 
@@ -16,7 +15,7 @@ import (
 // PSK - Pre-shared key for implant authentication
 var PSK string
 
-// HTTPServerHandler - Handles HTTPServer requests
+// HTTPServerHandler - Handles all HTTPS/HTTPServer requests
 func HTTPServerHandler(w http.ResponseWriter, r *http.Request) {
 	// Setup webserver attributes like headers and response information
 	w.Header().Set("Content-Type", "application/json")
@@ -45,7 +44,7 @@ func handleGetRequests(w http.ResponseWriter, r *http.Request) {
 	var getUpdate float64
 	var getData string
 	var getAdditionalFunctions string
-	var additionalFunctions []string
+	var additionalFunctions map[string]interface{}
 	var register bool
 	var err error
 
@@ -117,7 +116,7 @@ func handleGetRequests(w http.ResponseWriter, r *http.Request) {
 
 	if len(getParams["functions"]) > 0 {
 		getAdditionalFunctions = getParams["functions"][0]
-		additionalFunctions = strings.Split(getAdditionalFunctions, ",")
+		json.Unmarshal([]byte(getAdditionalFunctions), &additionalFunctions)
 	} else {
 		getAdditionalFunctions = ""
 	}
@@ -189,7 +188,7 @@ func handlePostRequests(w http.ResponseWriter, r *http.Request) {
 	var postUpdate float64
 	var postData string
 	var postAdditionalFunctions string
-	var additionalFunctions []string
+	var additionalFunctions map[string]interface{}
 	var register bool
 	var err error
 
@@ -261,7 +260,7 @@ func handlePostRequests(w http.ResponseWriter, r *http.Request) {
 
 	if len(postParams["functions"]) > 0 {
 		postAdditionalFunctions = postParams["functions"][0]
-		additionalFunctions = strings.Split(postAdditionalFunctions, ",")
+		json.Unmarshal([]byte(postAdditionalFunctions), &additionalFunctions)
 	} else {
 		postAdditionalFunctions = ""
 	}


### PR DESCRIPTION
Well, that was easy. Because of the handler abstraction the entire http.go server lib can be reused in TLS. The only difference is having to start the server with `ListenandServeTLS` and pass in the key/cert file locations. All the same handlers and hooks are fully re-usable.

This PR implements:
- HTTPS support for listeners (now default)
- Easy TLS generation bash script for self-signed cert with openssl
- Enhanced custom implant function hooks via JSON