### PR TITLE
added exec subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ TODO:
 - [x] Consider random PSK generation rather than a default base key
 - [x] Document "API" and consider pre-generating API documentation.
 - [ ] Document core features: TLS generation, custom functions (part of API but notable), implant baseline implementation
+- [x] Add Exec command to allow local shell interaction while in the Lupo CLI
 - [ ] Reformat the ASCII art so it is printed a bit more cleanly
 - [ ] Create demo implants to show off all the feature/functionality - documentation too
 - [ ] Repo art update and open source!

--- a/lupo-client/cmd/exec.go
+++ b/lupo-client/cmd/exec.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/InjectionSoftwareandSecurityLLC/lupo/lupo-client/core"
+	"github.com/desertbit/grumble"
+	"github.com/mattn/go-shellwords"
+)
+
+// init - Initializes the primary "exec" grumble command
+//
+// "exec" accepts an argument of "cmd" that will execute any local commands to around shell interaction with the host system without leaving the Lupo cli
+//
+
+func init() {
+
+	execCmd := &grumble.Command{
+		Name:     "exec",
+		Help:     "execute a local shell command",
+		LongHelp: "Executes a local shell command to allow interaction with the local system while remaining in the Lupo CLI",
+		Args: func(a *grumble.Args) {
+			a.StringList("cmd", "Command to execute on the local system")
+		},
+		Run: func(c *grumble.Context) error {
+
+			cmd := strings.Join(c.Args.StringList("cmd"), " ")
+
+			reqString := "&command="
+			commandString := "exec " + cmd
+
+			reqString = core.AuthURL + reqString + url.QueryEscape(commandString)
+
+			resp, err := core.WolfPackHTTP.Get(reqString)
+
+			if err != nil {
+				fmt.Println(err)
+				return nil
+			}
+
+			defer resp.Body.Close()
+
+			parsedCmd, err := shellwords.Parse(cmd)
+
+			// Get the root command
+			cmd = parsedCmd[0]
+
+			// Cut off the root command and extract any args if they exist
+			argS := parsedCmd[1:]
+
+			if err != nil {
+				return nil
+			}
+
+			// Check if it is a command with our without args and execute appropriately
+			if cmd != "" && len(argS) > 0 {
+				// Maintain directory context if cd is issued
+				if cmd == "cd" {
+					os.Chdir(strings.Join(argS, " "))
+				} else {
+					data, err := exec.Command(cmd, argS...).Output()
+
+					if err != nil {
+						return nil
+					}
+
+					fmt.Println(string(data))
+
+				}
+
+			} else if cmd != "" {
+
+				data, err := exec.Command(cmd).Output()
+
+				if err != nil {
+					return nil
+				}
+
+				fmt.Println(string(data))
+
+			}
+
+			return nil
+		},
+	}
+	App.AddCommand(execCmd)
+
+}

--- a/lupo-server/cmd/exec.go
+++ b/lupo-server/cmd/exec.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/InjectionSoftwareandSecurityLLC/lupo/lupo-server/core"
+	"github.com/InjectionSoftwareandSecurityLLC/lupo/lupo-server/server"
+	"github.com/desertbit/grumble"
+	"github.com/mattn/go-shellwords"
+)
+
+// init - Initializes the primary "exec" grumble command
+//
+// "exec" accepts an argument of "cmd" that will execute any local commands to around shell interaction with the host system without leaving the Lupo cli
+//
+
+func init() {
+
+	execCmd := &grumble.Command{
+		Name:     "exec",
+		Help:     "execute a local shell command",
+		LongHelp: "Executes a local shell command to allow interaction with the local system while remaining in the Lupo CLI",
+		Args: func(a *grumble.Args) {
+			a.StringList("cmd", "Command to execute on the local system")
+		},
+		Run: func(c *grumble.Context) error {
+
+			cmd := strings.Join(c.Args.StringList("cmd"), " ")
+
+			var operator string
+
+			operator = "server"
+
+			if server.IsWolfPackExec {
+				operator = server.CurrentOperator
+
+				core.LogData(operator + " executed: exec " + cmd)
+
+			} else {
+				core.LogData(operator + " executed: exec " + cmd)
+
+				parsedCmd, err := shellwords.Parse(cmd)
+
+				// Get the root command
+				cmd := parsedCmd[0]
+
+				// Cut off the root command and extract any args if they exist
+				argS := parsedCmd[1:]
+
+				if err != nil {
+					return nil
+				}
+
+				// Check if it is a command with our without args and execute appropriately
+				if cmd != "" && len(argS) > 0 {
+					// Maintain directory context if cd is issued
+					if cmd == "cd" {
+						os.Chdir(strings.Join(argS, " "))
+					} else {
+						data, err := exec.Command(cmd, argS...).Output()
+
+						if err != nil {
+							return nil
+						}
+
+						fmt.Println(string(data))
+
+					}
+
+				} else if cmd != "" {
+
+					data, err := exec.Command(cmd).Output()
+
+					if err != nil {
+						return nil
+					}
+
+					fmt.Println(string(data))
+
+				}
+
+			}
+
+			return nil
+		},
+	}
+	App.AddCommand(execCmd)
+
+}


### PR DESCRIPTION
This PR adds an exec subcommand to the server and client to allow interaction with the local shell of the host system without leaving the Lupo CLI. All exec commands are logged but not their output. 

The client checks in as well just to allow the server to log its exec but the actual exec will run on the client side only and not an exec from the server so not output is necessary to parse.