### PR TITLE
Updated makefile to remove uneeded ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 DIR=builds/
 LUPO_SERVER=LUPO_SERVER
 LUPO_CLIENT=LUPO_CLIENT
-WIN_LDFLAGS=-ldflags "-H=windowsgui"
 W=Windows-x64
 L=Linux-x64
 A=Linux-arm
@@ -42,7 +41,7 @@ mips: LUPO_SERVER-mips LUPO_CLIENT-mips
 
 # Compile LUPO_SERVER - Windows x64
 LUPO_SERVER-windows:
-	export GOOS=windows GOARCH=amd64;go build ${WIN_LDFLAGS} -o ${DIR}/${LUPO_SERVER}-${W}.exe lupo-server/main.go
+	export GOOS=windows GOARCH=amd64;go build -o ${DIR}/${LUPO_SERVER}-${W}.exe lupo-server/main.go
 
 # Compile LUPO_SERVER - Linux x64
 LUPO_SERVER-linux:
@@ -62,7 +61,7 @@ LUPO_SERVER-arm:
 
 # Compile LUPO_CLIENT - Windows x64
 LUPO_CLIENT-windows:
-	export GOOS=windows GOARCH=amd64;go build ${WIN_LDFLAGS} -o ${DIR}/${LUPO_CLIENT}-${W}.exe lupo-client/main.go
+	export GOOS=windows GOARCH=amd64;go build -o ${DIR}/${LUPO_CLIENT}-${W}.exe lupo-client/main.go
 
 # Compile LUPO_CLIENT - Linux x64
 LUPO_CLIENT-linux:


### PR DESCRIPTION
# Pull Request

## Description
This removes an a build flag from the makefile for windows versions of lupo that is not needed. This flag allows the binary to run in the background which is great for implants but breaks interaction with the server binary on Windows. Simply removing the flag fixes it.

## Features
- Fixes the lupo server/client builds on windows


## Screenshot(s)/Change Detail(s) (Optional)
```
export GOOS=windows GOARCH=amd64;go build -o builds//LUPO_SERVER-Windows-x64.exe lupo-server/main.go
export GOOS=linux;export GOARCH=amd64;go build -o builds//LUPO_SERVER-Linux-x64 lupo-server/main.go
export GOOS=darwin;export GOARCH=amd64;go build -o builds//LUPO_SERVER-Darwin-x64 lupo-server/main.go
export GOOS=windows GOARCH=amd64;go build -o builds//LUPO_CLIENT-Windows-x64.exe lupo-client/main.go
export GOOS=linux;export GOARCH=amd64;go build -o builds//LUPO_CLIENT-Linux-x64 lupo-client/main.go
export GOOS=darwin;export GOARCH=amd64;go build -o builds//LUPO_CLIENT-Darwin-x64 lupo-client/main.go
```