### PR TITLE
Dev/path bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ v0.1.0 (BETA) Features:
 - [x] implement automated builds with Travis CI
 
 Known Bugs:
-- [ ] Fix issue that prevents full config path from being read by client binary
 - [ ] Implement a cleaner mechanism for handling server shutdown if the user accidentally starts a second Wolfpack server so a dangling instance isn't left.
 
 

--- a/lupo-client/cmd/lupo.go
+++ b/lupo-client/cmd/lupo.go
@@ -23,6 +23,9 @@ var lupoApp = grumble.New(&grumble.Config{
 	HelpHeadlineColor:     color.New(color.FgWhite),
 	HelpHeadlineUnderline: true,
 	HelpSubCommands:       true,
+	Flags: func(f *grumble.Flags) {
+		f.String("c", "config", "wolfpack.json", "config file for lupo client, expects default filename to exist if not specified")
+	},
 })
 
 // App - Primary grumble CLI construction variable for switching nested app contexts


### PR DESCRIPTION
# Pull Request

## Description
This fixes a bug in the lupo client where the "-c" flag would not accept a full path to a config file and would only read the config if it existed in the same directory as the lupo client. This was caused by a conflict of the grumble CLI not playing nice with the golang flags library. By simply redefining the "-c" flag in the lupo app the conflict is resolved. Might be good in the future to figure out how to use  the  built in grumble flag, but since we can't run functions that read grumble flags on init this workaround will suffice.

## Features
- Fixes the "-c" flag bug to allow users to read in wolfpack configs in the lupo client from any path not just the current directory of the client.