### PR TITLE
Dev/path config fix

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'dev/v.0.1.0-beta-release'
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Build Status
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ v0.1.0 (BETA) Features:
 - [x] implement automated builds with Travis CI
 
 Known Bugs:
-- [ ] Fix issue that prevents full config path from being read by client binary
+- [x] Fix issue that prevents full config path from being read by client binary
 - [ ] Implement a cleaner mechanism for handling server shutdown if the user accidentally starts a second Wolfpack server so a dangling instance isn't left.
 
 

--- a/lupo-client/cmd/lupo.go
+++ b/lupo-client/cmd/lupo.go
@@ -23,6 +23,9 @@ var lupoApp = grumble.New(&grumble.Config{
 	HelpHeadlineColor:     color.New(color.FgWhite),
 	HelpHeadlineUnderline: true,
 	HelpSubCommands:       true,
+	Flags: func(f *grumble.Flags) {
+		f.String("c", "config", "wolfpack.json", "config file for lupo client, expects default filename to exist if not specified")
+	},
 })
 
 // App - Primary grumble CLI construction variable for switching nested app contexts


### PR DESCRIPTION
# Pull Request

## Description
Fixes config absolute path issue in lupo client. Workaround required a grumble flag to be initialized with the same name as the flags library as a conflict was caused between the two. In the future it may be better to switch to using the grumble flag only, but there's no way to pre-process the data in the current state before grumble is initialized so it'll work fine as is for now.

## Features
- Fixes config path bug in lupo client